### PR TITLE
Fix compile issues with egui_node_graph

### DIFF
--- a/src/editor/app.rs
+++ b/src/editor/app.rs
@@ -242,7 +242,7 @@ impl eframe::App for PlcEditorApp {
         egui::CentralPanel::default().show(ctx, |ui| {
             let graph_response = self.state.draw_graph_editor(
                 ui,
-                AllNodeTemplates(PlcNodeTemplate::all_templates()),
+                PlcNodeTemplate::all_templates(),
                 &mut self.user_state,
             );
             
@@ -292,7 +292,7 @@ impl eframe::App for PlcEditorApp {
                                     if self.node_finder_search.is_empty() || 
                                        template.name.to_lowercase().contains(&self.node_finder_search.to_lowercase()) {
                                         if ui.button(&template.name).clicked() {
-                                            let graph = self.state.graph_mut();
+                                            let graph = &mut self.state.graph;
                                             let node_id = graph.add_node(
                                                 template.name.clone(),
                                                 template.user_data(&mut self.user_state),
@@ -302,7 +302,7 @@ impl eframe::App for PlcEditorApp {
                                             );
                                             
                                             // Position at center of viewport
-                                            let center = ctx.screen_rect().center();
+                                            let center = ctx.available_rect().center();
                                             self.state.node_positions.insert(node_id, center);
                                             self.modified = true;
                                             self.show_node_finder = false;

--- a/src/editor/export.rs
+++ b/src/editor/export.rs
@@ -1,6 +1,6 @@
 use super::{PlcNodeData, PlcDataType};
 use crate::blocks::BlockConfig;
-use egui_node_graph::{NodeId, OutputId, InputId};
+use egui_node_graph::{NodeId, OutputId};
 use std::collections::HashMap;
 
 pub type PlcGraph = egui_node_graph::Graph<PlcNodeData, PlcDataType, super::PlcValueType>;
@@ -27,14 +27,21 @@ impl YamlExporter {
         let mut signals = Vec::new();
         let mut blocks = Vec::new();
         let mut signal_map: HashMap<OutputId, String> = HashMap::new();
-        
+
         // First pass: create signals for all connections
-        for (_conn_id, connection) in &self.graph.connections {
+        let connections: Vec<_> = self
+            .graph
+            .connections
+            .iter()
+            .map(|(input, output)| (*input, *output))
+            .collect();
+
+        for (_input_id, output_id) in connections {
             let signal_name = self.generate_signal_name("signal");
-            signal_map.insert(connection.output, signal_name.clone());
-            
+            signal_map.insert(output_id, signal_name.clone());
+
             // Determine signal type from output
-            let output = self.graph.get_output(connection.output);
+            let output = self.graph.get_output(output_id);
             let signal_type = match output.typ {
                 PlcDataType::Bool => "bool",
                 PlcDataType::Int => "int",
@@ -103,9 +110,8 @@ impl YamlExporter {
         
         // Map inputs
         for (param_name, input_id) in &node.inputs {
-            if let Some(connection) = self.graph.connections.iter()
-                .find(|(_, conn)| conn.input == *input_id) {
-                if let Some(signal_name) = signal_map.get(&connection.1.output) {
+            if let Some(output_id) = self.graph.connections.get(*input_id) {
+                if let Some(signal_name) = signal_map.get(output_id) {
                     inputs.insert(param_name.clone(), signal_name.clone());
                 }
             }


### PR DESCRIPTION
## Summary
- refactor connection loop in exporter to avoid borrow errors
- dereference input IDs when mapping connections
- use a simple Vec for node templates in `draw_graph_editor`

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6849e161aef4832c9c4c0ce076a9c42f