### PR TITLE
Fix compile issues with egui_node_graph

### DIFF
--- a/src/editor/app.rs
+++ b/src/editor/app.rs
@@ -242,7 +242,7 @@ impl eframe::App for PlcEditorApp {
         egui::CentralPanel::default().show(ctx, |ui| {
             let graph_response = self.state.draw_graph_editor(
                 ui,
-                AllNodeTemplates(PlcNodeTemplate::all_templates()),
+                PlcNodeTemplate::all_templates(),
                 &mut self.user_state,
             );
             
@@ -292,7 +292,7 @@ impl eframe::App for PlcEditorApp {
                                     if self.node_finder_search.is_empty() || 
                                        template.name.to_lowercase().contains(&self.node_finder_search.to_lowercase()) {
                                         if ui.button(&template.name).clicked() {
-                                            let graph = self.state.graph_mut();
+                                            let graph = &mut self.state.graph;
                                             let node_id = graph.add_node(
                                                 template.name.clone(),
                                                 template.user_data(&mut self.user_state),
@@ -302,7 +302,7 @@ impl eframe::App for PlcEditorApp {
                                             );
                                             
                                             // Position at center of viewport
-                                            let center = ctx.screen_rect().center();
+                                            let center = ctx.available_rect().center();
                                             self.state.node_positions.insert(node_id, center);
                                             self.modified = true;
                                             self.show_node_finder = false;


### PR DESCRIPTION
## Summary
- refactor connection loop in exporter to avoid borrow errors
- dereference input IDs when mapping connections
- use a simple Vec for node templates in draw_graph_editor
- add comment marking end of `YamlExporter` implementation

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6849e161aef4832c9c4c0ce076a9c42f