### PR TITLE
Fix compile error in YamlExporter

### DIFF
--- a/src/editor/export.rs
+++ b/src/editor/export.rs
@@ -43,13 +43,6 @@ impl YamlExporter {
             // Determine signal type from output
             let output = self.graph.get_output(output_id);
 
-        for (_input_id, output_id) in &self.graph.connections {
-            let signal_name = self.generate_signal_name("signal");
-            signal_map.insert(*output_id, signal_name.clone());
-
-            // Determine signal type from output
-            let output = self.graph.get_output(*output_id);
-
             let signal_type = match output.typ {
                 PlcDataType::Bool => "bool",
                 PlcDataType::Int => "int",


### PR DESCRIPTION
## Summary
- fix duplicated `for` loop in `YamlExporter` so delimiters match

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6849f4183538832c949786060e7f1747