### PR TITLE
Fix compile errors in editor

### DIFF
--- a/src/editor/app.rs
+++ b/src/editor/app.rs
@@ -242,11 +242,7 @@ impl eframe::App for PlcEditorApp {
         egui::CentralPanel::default().show(ctx, |ui| {
             let graph_response = self.state.draw_graph_editor(
                 ui,
-
-                PlcNodeTemplate::all_templates(),
-
                 egui_node_graph::AllNodeTemplates(PlcNodeTemplate::all_templates()),
-
                 &mut self.user_state,
             );
             

--- a/src/editor/export.rs
+++ b/src/editor/export.rs
@@ -29,19 +29,12 @@ impl YamlExporter {
         let mut signal_map: HashMap<OutputId, String> = HashMap::new();
 
         // First pass: create signals for all connections
-        let connections: Vec<_> = self
-            .graph
-            .connections
-            .iter()
-            .map(|(input, output)| (*input, *output))
-            .collect();
-
-        for (_input_id, output_id) in connections {
+        for (_input_id, output_id) in &self.graph.connections {
             let signal_name = self.generate_signal_name("signal");
-            signal_map.insert(output_id, signal_name.clone());
+            signal_map.insert(*output_id, signal_name.clone());
 
             // Determine signal type from output
-            let output = self.graph.get_output(output_id);
+            let output = self.graph.get_output(*output_id);
 
             let signal_type = match output.typ {
                 PlcDataType::Bool => "bool",
@@ -111,11 +104,7 @@ impl YamlExporter {
         
         // Map inputs
         for (param_name, input_id) in &node.inputs {
-
-            if let Some(output_id) = self.graph.connections.get(*input_id) {
-
-
-
+            if let Some(output_id) = self.graph.connections.get(input_id) {
                 if let Some(signal_name) = signal_map.get(output_id) {
                     inputs.insert(param_name.clone(), signal_name.clone());
                 }


### PR DESCRIPTION
## Summary
- pass node templates directly to `draw_graph_editor`
- simplify connection handling when exporting YAML

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6849f6438360832cbc6fce6bac924d2c