### PR TITLE
Fix compile errors in editor

### DIFF
--- a/src/editor/app.rs
+++ b/src/editor/app.rs
@@ -241,7 +241,9 @@ impl eframe::App for PlcEditorApp {
         // Central panel with node graph
         egui::CentralPanel::default().show(ctx, |ui| {
             let templates = PlcNodeTemplate::all_templates();
-            let graph_response = self.state.draw_graph_editor(ui, templates, &mut self.user_state);
+            let graph_response =
+                self.state
+                    .draw_graph_editor(ui, templates.iter().cloned(), &mut self.user_state);
             
             // Handle graph responses
             for response in graph_response.node_responses {

--- a/src/editor/export.rs
+++ b/src/editor/export.rs
@@ -30,7 +30,11 @@ impl YamlExporter {
 
         // First pass: create signals for all connections
         let connection_list: Vec<(InputId, OutputId)> =
-            self.graph.connections.iter().map(|(i, o)| (*i, *o)).collect();
+            self.graph
+                .connections
+                .iter()
+                .map(|(&i, &o)| (i, o))
+                .collect();
         for (_input_id, output_id) in connection_list {
             let signal_name = self.generate_signal_name("signal");
             signal_map.insert(*output_id, signal_name.clone());


### PR DESCRIPTION
## Summary
- implement NodeTemplateIter by passing iterator when drawing graph
- correct connection iteration in YAML exporter

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6849fc761c78832c824a431487b75af4