### PR TITLE
Fix compile issues in PLC editor

### DIFF
--- a/src/editor/app.rs
+++ b/src/editor/app.rs
@@ -243,7 +243,7 @@ impl eframe::App for PlcEditorApp {
             let templates = PlcNodeTemplate::all_templates();
             let graph_response =
                 self.state
-                    .draw_graph_editor(ui, templates.iter().cloned(), &mut self.user_state);
+                    .draw_graph_editor(ui, templates, &mut self.user_state);
             
             // Handle graph responses
             for response in graph_response.node_responses {

--- a/src/editor/export.rs
+++ b/src/editor/export.rs
@@ -37,10 +37,10 @@ impl YamlExporter {
                 .collect();
         for (_input_id, output_id) in connection_list {
             let signal_name = self.generate_signal_name("signal");
-            signal_map.insert(*output_id, signal_name.clone());
+            signal_map.insert(output_id, signal_name.clone());
 
             // Determine signal type from output
-            let output = self.graph.get_output(*output_id);
+            let output = self.graph.get_output(output_id);
 
             let signal_type = match output.typ {
                 PlcDataType::Bool => "bool",


### PR DESCRIPTION
## Summary
- fix `draw_graph_editor` call to pass templates directly
- remove unneeded dereferences when exporting YAML

## Testing
- `cargo check` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6849fe0f2658832c8d7e670d318bb466