### PR TITLE
Fix missing NodeTemplateIter impl

### DIFF
--- a/src/editor/templates.rs
+++ b/src/editor/templates.rs
@@ -99,6 +99,15 @@ impl PlcNodeTemplate {
     }
 }
 
+// Allow Vec<PlcNodeTemplate> to be passed directly to graph editor APIs
+impl egui_node_graph::NodeTemplateIter for Vec<PlcNodeTemplate> {
+    type Item = PlcNodeTemplate;
+
+    fn all_kinds(self) -> Vec<Self::Item> {
+        self
+    }
+}
+
 impl NodeTemplateTrait for PlcNodeTemplate {
     type NodeData = PlcNodeData;
     type DataType = PlcDataType;


### PR DESCRIPTION
## Summary
- implement `NodeTemplateIter` for `Vec<PlcNodeTemplate>` so the editor can pass node templates directly to the graph editor

## Testing
- `cargo check` *(fails: failed to download crates from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_684a03317114832cb927bedd5406fe36