### PR TITLE
Fix missing delimiter in templates

### DIFF
--- a/src/editor/templates.rs
+++ b/src/editor/templates.rs
@@ -95,7 +95,7 @@ impl PlcNodeTemplate {
             },
             
             // Add more templates as needed...
-        ]
+        ])
     }
 }
 


### PR DESCRIPTION
## Summary
- close function call with `])` in `templates.rs`

## Testing
- `cargo test --quiet` *(fails: glib-2.0 pkg-config not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a15be016c832c8cd42f37fe7e8509