### PR TITLE
Fix NodeTemplateIter trait implementation

### DIFF
--- a/src/editor/templates.rs
+++ b/src/editor/templates.rs
@@ -139,8 +139,8 @@ impl<'a> IntoIterator for &'a PlcNodeTemplates {
 impl egui_node_graph::NodeTemplateIter for PlcNodeTemplates {
     type Item = PlcNodeTemplate;
 
-    fn all_kinds(self) -> Vec<Self::Item> {
-        self.0
+    fn all_kinds(&self) -> Vec<Self::Item> {
+        self.0.clone()
     }
 }
 


### PR DESCRIPTION
## Summary
- implement NodeTemplateIter::all_kinds with `&self` receiver

## Testing
- `cargo check --lib`
- `cargo test --no-run` *(fails: could not compile `soft-plc` due to earlier error)*

------
https://chatgpt.com/codex/tasks/task_e_684a52d58d70832c9dbb2e93b4069a54