### PR TITLE
Fix plc_editor main for eframe 0.19

### DIFF
--- a/src/bin/plc_editor.rs
+++ b/src/bin/plc_editor.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
-use soft_plc::editor::{PlcEditorApp, PlcNodeTemplate};
+use soft_plc::editor::PlcEditorApp;
 
-fn main() -> Result<(), eframe::Error> {
+fn main() {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(1400.0, 900.0)),
         ..Default::default()
@@ -11,5 +11,5 @@ fn main() -> Result<(), eframe::Error> {
         "Soft-PLC Visual Editor",
         options,
         Box::new(|cc| Box::new(PlcEditorApp::new(cc))),
-    )
+    );
 }


### PR DESCRIPTION
## Summary
- adjust `plc_editor` to match eframe 0.19 API

## Testing
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5a403880832caf5f1a7fd3f28c08